### PR TITLE
Enable Pagination + Advanced Filter in URL

### DIFF
--- a/src/App/components/booking/BookingList.tsx
+++ b/src/App/components/booking/BookingList.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import { Tag, Table } from 'antd'
 import moment from 'moment'
 
-import { Link } from 'react-router-dom'
+import { IListProps } from '../types/shared'
 
-const BookingList: React.FC<{ data: any[] }> = ({ data }) => {
+const BookingList: React.FC<IListProps> = ({ data, current, onPaginationChange }) => {
   const columns = useMemo(() => [
     {
       title: 'Booking',
@@ -76,7 +77,21 @@ const BookingList: React.FC<{ data: any[] }> = ({ data }) => {
     }
   ], [])
 
-  return <Table columns={columns} dataSource={data} rowKey={(data) => data.id} />
+  return (
+    <Table
+      columns={columns}
+      dataSource={data.rows}
+      rowKey={(data) => data.id}
+      pagination={{
+        current: +current,
+        defaultCurrent: 1,
+        defaultPageSize: 10,
+        total: data.count,
+        simple: true,
+        onChange: onPaginationChange
+      }}
+    />
+  )
 }
 
 export default BookingList

--- a/src/App/components/contact/ContactList.tsx
+++ b/src/App/components/contact/ContactList.tsx
@@ -1,12 +1,11 @@
 import React, { useMemo } from 'react'
-import { Link, useHistory } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { Table, Tag } from 'antd'
 
 import { ROLE } from '../types/contact'
+import { IListProps } from '../types/shared'
 
-const ContactList: React.FC<{ data: Record<string, any>, current: string }> = ({ data, current }) => {
-  const history = useHistory()
-
+const ContactList: React.FC<IListProps> = ({ data, current, onPaginationChange }) => {
   const columns = useMemo(() => [
     {
       title: 'Company Name',
@@ -47,7 +46,7 @@ const ContactList: React.FC<{ data: Record<string, any>, current: string }> = ({
         defaultPageSize: 10,
         total: data.count,
         simple: true,
-        onChange: (page) => history.push(`?page=${page}`)
+        onChange: onPaginationChange
       }}
     />
   )

--- a/src/App/components/purchaseOrder/PurchaseOrderList.tsx
+++ b/src/App/components/purchaseOrder/PurchaseOrderList.tsx
@@ -1,12 +1,11 @@
 import React, { useMemo } from 'react'
-import { Link, useHistory } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { Table, Tag } from 'antd'
 
 import { STATUS } from '../types/purchaseOrder'
+import { IListProps } from '../types/shared'
 
-const PurchaseOrderList: React.FC<{ data: Record<string, any>, current: string }> = ({ data, current }) => {
-  const history = useHistory()
-
+const PurchaseOrderList: React.FC<IListProps> = ({ data, current, onPaginationChange }) => {
   const columns = useMemo(() => [
     {
       title: 'Purchase Order',
@@ -50,7 +49,7 @@ const PurchaseOrderList: React.FC<{ data: Record<string, any>, current: string }
         defaultPageSize: 10,
         total: data.count,
         simple: true,
-        onChange: (page) => history.push(`?page=${page}`)
+        onChange: onPaginationChange
       }}
     />
   )

--- a/src/App/components/shipment/ShipmentList.tsx
+++ b/src/App/components/shipment/ShipmentList.tsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from 'react'
-import { Table, Tag } from 'antd'
-
-import { STATUS } from '../types/shipment'
 import { Link } from 'react-router-dom'
+import { Table, Tag } from 'antd'
 import moment from 'moment'
-// import { data } from '../../mock/shipment'
 
-const ShipmentList: React.FC<{ data: any[] }> = ({ data }) => {
+import { IListProps } from '../types/shared'
+import { STATUS } from '../types/shipment'
+
+const ShipmentList: React.FC<IListProps> = ({ data, current, onPaginationChange }) => {
   const columns = useMemo(() => [
     {
       title: 'Id',
@@ -110,7 +110,21 @@ const ShipmentList: React.FC<{ data: any[] }> = ({ data }) => {
   //   setValues(null)
   // }
 
-  return <Table columns={columns} dataSource={data} rowKey={(data) => data.id} />
+  return (
+    <Table
+      columns={columns}
+      dataSource={data.rows}
+      rowKey={(data) => data.id}
+      pagination={{
+        current: +current,
+        defaultCurrent: 1,
+        defaultPageSize: 10,
+        total: data.count,
+        simple: true,
+        onChange: onPaginationChange
+      }}
+    />
+  )
 }
 
 export default ShipmentList

--- a/src/App/components/types/shared.ts
+++ b/src/App/components/types/shared.ts
@@ -2,3 +2,9 @@ export interface IFormProps<T> {
   initialValues?: T;
   disabled?: boolean;
 }
+
+export interface IListProps {
+  data: Record<string, any>;
+  current: string;
+  onPaginationChange: (page: number) => void;
+}

--- a/src/App/components/vessel/VesselList.tsx
+++ b/src/App/components/vessel/VesselList.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo } from 'react'
-import { Link, useHistory } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { Table } from 'antd'
 import moment from 'moment'
 
-const VesselList: React.FC<{ data: Record<string, any>, current: string }> = ({ data, current }) => {
-  const history = useHistory()
+import { IListProps } from '../types/shared'
 
+const VesselList: React.FC<IListProps> = ({ data, current, onPaginationChange }) => {
   const columns = useMemo(() => [
     {
       title: 'Vessel Name',
@@ -38,7 +38,7 @@ const VesselList: React.FC<{ data: Record<string, any>, current: string }> = ({ 
         defaultPageSize: 10,
         total: data.count,
         simple: true,
-        onChange: (page) => history.push(`?page=${page}`)
+        onChange: onPaginationChange
       }}
     />
   )

--- a/src/App/pages/booking/booking.tsx
+++ b/src/App/pages/booking/booking.tsx
@@ -40,6 +40,7 @@ const BookingPage: React.FC = (props) => {
   }, [search])
 
   const handleFilterSave = useCallback((values: Record<string, string>) => history.push(`?${stringify(values)}`), [history, stringify])
+  const handlePaginationChange = useCallback((page: number) => history.push(`?${stringify({ ...searchQuery, page })}`), [history, searchQuery, stringify])
 
   return (
     <Nav>
@@ -52,7 +53,7 @@ const BookingPage: React.FC = (props) => {
         }}
         type='booking'
       />
-      <BookingList data={data} />
+      <BookingList data={data} current={(searchQuery.page as string) ?? '1'} onPaginationChange={handlePaginationChange} />
     </Nav>
   )
 }

--- a/src/App/pages/contact/contact.tsx
+++ b/src/App/pages/contact/contact.tsx
@@ -33,6 +33,7 @@ const ContactPage: React.FC = (props) => {
   }, [search])
 
   const handleFilterSave = useCallback((values: Record<string, string>) => history.push(`?${stringify(values)}`), [history, stringify])
+  const handlePaginationChange = useCallback((page: number) => history.push(`?${stringify({ ...searchQuery, page })}`), [history, searchQuery, stringify])
 
   return (
     <Nav>
@@ -45,7 +46,7 @@ const ContactPage: React.FC = (props) => {
           placeholder: 'Search by Contact'
         }}
       />
-      <ContactList data={data} current={(searchQuery.page as string) ?? '1'} />
+      <ContactList data={data} current={(searchQuery.page as string) ?? '1'} onPaginationChange={handlePaginationChange} />
     </Nav>
   )
 }

--- a/src/App/pages/purchase-order/purchase-order.tsx
+++ b/src/App/pages/purchase-order/purchase-order.tsx
@@ -34,6 +34,7 @@ const PurchaseOrderPage: React.FC = (props) => {
   }, [search])
 
   const handleFilterSave = useCallback((values: Record<string, string>) => history.push(`?${stringify(values)}`), [history, stringify])
+  const handlePaginationChange = useCallback((page: number) => history.push(`?${stringify({ ...searchQuery, page })}`), [history, searchQuery, stringify])
 
   return (
     <Nav>
@@ -46,7 +47,7 @@ const PurchaseOrderPage: React.FC = (props) => {
           placeholder: 'Search by Purchase Order'
         }}
       />
-      <PurchaseOrderList data={data} current={(searchQuery.page as string) ?? '1'} />
+      <PurchaseOrderList data={data} current={(searchQuery.page as string) ?? '1'} onPaginationChange={handlePaginationChange} />
     </Nav>
   )
 }

--- a/src/App/pages/shipment/shipment.tsx
+++ b/src/App/pages/shipment/shipment.tsx
@@ -33,6 +33,7 @@ const ShipmentPage: React.FC = (props) => {
   }, [search])
 
   const handleFilterSave = useCallback((values: Record<string, string>) => history.push(`?${stringify(values)}`), [history, stringify])
+  const handlePaginationChange = useCallback((page: number) => history.push(`?${stringify({ ...searchQuery, page })}`), [history, searchQuery, stringify])
 
   return (
     <Nav>
@@ -45,7 +46,7 @@ const ShipmentPage: React.FC = (props) => {
           placeholder: 'Search by Container No.'
         }}
       />
-      <ShipmentList data={data} />
+      <ShipmentList data={data} current={(searchQuery.page as string) ?? '1'} onPaginationChange={handlePaginationChange} />
     </Nav>
   )
 }

--- a/src/App/pages/vessel/vessel.tsx
+++ b/src/App/pages/vessel/vessel.tsx
@@ -41,6 +41,7 @@ const VesselPage: React.FC = (props) => {
   }, [search])
 
   const handleFilterSave = useCallback((values: Record<string, string>) => history.push(`?${stringify(values)}`), [history, stringify])
+  const handlePaginationChange = useCallback((page: number) => history.push(`?${stringify({ ...searchQuery, page })}`), [history, searchQuery, stringify])
 
   return (
     <Nav>
@@ -53,7 +54,7 @@ const VesselPage: React.FC = (props) => {
           placeholder: 'Search by Vessel'
         }}
       />
-      <VesselList data={data} current={(searchQuery.page as string) ?? '1'} />
+      <VesselList data={data} current={(searchQuery.page as string) ?? '1'} onPaginationChange={handlePaginationChange} />
     </Nav>
   )
 }


### PR DESCRIPTION
(BE) Required to use `findAndCountAll` for `booking`, `purchase-order` and `shipment`.